### PR TITLE
there might be some optional output from smbclient before the prompt

### DIFF
--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -48,7 +48,7 @@ module Sambal
         @o, @i, @pid = PTY.spawn("smbclient //#{options[:host]}/#{options[:share]} #{options[:password]} -W #{options[:domain]} -U #{options[:user]} -p #{options[:port]}")
         #@o.set_encoding('UTF-8:UTF-8') ## don't know didn't work, we only have this problem when the files are named using non-english characters
         #@i.set_encoding('UTF-8:UTF-8')
-        res = @o.expect(/^smb:.*\\>/, 10)[0] rescue nil
+        res = @o.expect(/(.*\n)?smb:.*\\>/, 10)[0] rescue nil
         @connected = case res
         when nil
           $stderr.puts "Failed to connect"


### PR DESCRIPTION
there might be some optional output from smbclient before showing the
prompt

e.g.:
Domain=[EU] OS=[Windows 5.0] Server=[Windows 2000 LAN Manager]
smb: \>

the expect statement in the connection code looks only for the prompt.