### PR TITLE
Fix logins shares with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It should be available in a similar way on all major Linux distributions.
     client.put("local_file.txt","remote_file.txt") # uploads file to server
     client.put_content("My content here", "remote_file") # uploads content to a file on server
     client.get("remote_file.txt", "local_file.txt") # downloads file from server
-    client.delete("remote_file.txt") # deletes files from server
+    client.del("remote_file.txt") # deletes files from server
     client.cd("some_directory") # changes directory on server
     client.close # closes connection
 

--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -45,7 +45,7 @@ module Sambal
     def initialize(options={})
       begin
         options = {domain: 'WORKGROUP', host: '127.0.0.1', share: '', user: 'guest', password: '--no-pass', port: 445}.merge(options)
-        @o, @i, @pid = PTY.spawn("smbclient //#{options[:host]}/#{options[:share]} #{options[:password]} -W #{options[:domain]} -U #{options[:user]} -p #{options[:port]}")
+        @o, @i, @pid = PTY.spawn("smbclient \"//#{options[:host]}/#{options[:share]}\" \"#{options[:password]}\" -W \"#{options[:domain]}\" -U \"#{options[:user]}\" -p #{options[:port]}")
         #@o.set_encoding('UTF-8:UTF-8') ## don't know didn't work, we only have this problem when the files are named using non-english characters
         #@i.set_encoding('UTF-8:UTF-8')
         res = @o.expect(/(.*\n)?smb:.*\\>/, 10)[0] rescue nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
   
   ## perhaps this should be removed as well
   ## and done in Rakefile?
-  config.color_enabled = true
+  config.color = true
   ## dont do this, do it in Rakefile instead
   #config.formatter = 'd'
 


### PR DESCRIPTION
Hi there --

Really just two small changes:

1. Update the call to smbclient with quotation marks around parameters to support shares or usernames with spaces in them.

2. Fix a mistake in the README that refers to client.delete whereas it should be client.del

Also made a small change to spec_helper - config.color_enabled has been changed to config.color in the latest version of rspec (3.0.0).

Cheers,
Mike.