### PR TITLE
Added timeout option to initializer to permit wait longer than 10s

### DIFF
--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -44,11 +44,12 @@ module Sambal
 
     def initialize(options={})
       begin
-        options = {domain: 'WORKGROUP', host: '127.0.0.1', share: '', user: 'guest', password: '--no-pass', port: 445}.merge(options)
+        options = {domain: 'WORKGROUP', host: '127.0.0.1', share: '', user: 'guest', password: '--no-pass', port: 445, timeout: 10}.merge(options)
+        @timeout = options[:timeout].to_i
         @o, @i, @pid = PTY.spawn("smbclient \"//#{options[:host]}/#{options[:share]}\" \"#{options[:password]}\" -W \"#{options[:domain]}\" -U \"#{options[:user]}\" -p #{options[:port]}")
         #@o.set_encoding('UTF-8:UTF-8') ## don't know didn't work, we only have this problem when the files are named using non-english characters
         #@i.set_encoding('UTF-8:UTF-8')
-        res = @o.expect(/(.*\n)?smb:.*\\>/, 10)[0] rescue nil
+        res = @o.expect(/(.*\n)?smb:.*\\>/, @timeout)[0] rescue nil
         @connected = case res
         when nil
           $stderr.puts "Failed to connect"
@@ -234,7 +235,7 @@ module Sambal
 
     def ask(cmd)
       @i.printf("#{cmd}\n")
-      response = @o.expect(/^smb:.*\\>/,10)[0] rescue nil
+      response = @o.expect(/^smb:.*\\>/,@timeout)[0] rescue nil
       if response.nil?
         $stderr.puts "Failed to do #{cmd}"
         raise Exception.new, "Failed to do #{cmd}"


### PR DESCRIPTION
I found I was getting timeouts when copying large files across the network (1-2GB in size), so I added a timeout option to the initializer (defaults to 10 still).