### PR TITLE
Pathname support

### DIFF
--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -250,7 +250,7 @@ module Sambal
 
     def wrap_filenames(cmd,filenames)
       filenames = [filenames] unless filenames.kind_of?(Array)
-      filenames.map!{ |filename| '"' + filename + '"' }
+      filenames.map!{ |filename| "\"#{filename}\"" }
       [cmd,filenames].flatten.join(' ')
     end
 

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -201,7 +201,7 @@ describe Sambal::Client do
   end
 
   it 'should create commands with one wrapped filename' do
-    @sambal_client.wrap_filenames('cmd',['file1','file2']).should eq('cmd "file1" "file2"')
+    @sambal_client.wrap_filenames('cmd','file1').should eq('cmd "file1"')
   end
 
   it 'should create commands with more than one wrapped filename' do

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -208,4 +208,8 @@ describe Sambal::Client do
     @sambal_client.wrap_filenames('cmd',['file1','file2']).should eq('cmd "file1" "file2"')
   end
 
+  it 'should create commands with pathnames instead of strings' do
+    @sambal_client.wrap_filenames('cmd',[Pathname.new('file1'), Pathname.new('file2')]).should eq('cmd "file1" "file2"')
+  end
+
 end


### PR DESCRIPTION
Hi,

In most of the Rails apps file paths are being wrapped in a `Pathname`. Here's a quick fix to avoid explicit conversion to string on calling `get`, `put`, etc.

P.S. Also noticed a typo in one of the existing tests, fixed.