### PR TITLE
Use local ./tmp directory for testing

### DIFF
--- a/lib/sambal/test_server.rb
+++ b/lib/sambal/test_server.rb
@@ -31,15 +31,17 @@ module Sambal
     attr_reader :run_as
     attr_reader :host
 
-    def initialize(root_path="/tmp/sambal_test_server_#{Time.now.to_i}", share_name='sambal_test', run_as=ENV['USER'])
-      @erb_path = "#{File.expand_path(File.dirname(__FILE__))}/smb.conf.erb"
+    def initialize(root_path="../../tmp/sambal_test_server_#{Time.now.to_i}", share_name='sambal_test', run_as=ENV['USER'])
+      current_working_dir = Pathname.new(File.expand_path(File.dirname(__FILE__)))
+
+      @erb_path = current_working_dir.join("smb.conf.erb")
       @host = "127.0.0.1" ## will always just be localhost
-      @root_path = root_path
-      @share_path = "#{root_path}/share"
+      @root_path = current_working_dir.join(root_path)
+      @share_path = @root_path.join("share/")
       @share_name = share_name
-      @config_path = "#{root_path}/smb.conf"
-      @lock_path = "#{root_path}"
-      @pid_dir = "#{root_path}"
+      @config_path = @root_path.join("smb.conf")
+      @lock_path = @root_path
+      @pid_dir = @root_path
       @port = Random.new(Time.now.to_i).rand(2345..5678).to_i
       @run_as = run_as
       FileUtils.mkdir_p @share_path

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -28,10 +28,13 @@ describe Sambal::Client do
     FileUtils.chmod 0775, "#{test_server.share_path}/#{test_directory}"
     FileUtils.chmod 0777, "#{test_server.share_path}/#{testfile}"
     @sambal_client.cd('/')
+
+    FileUtils.mkdir_p(downloads_path)
   end
 
   after(:all) do
     @sambal_client.close
+    FileUtils.rm_rf(downloads_path)
   end
 
   let(:file_to_upload) do
@@ -80,6 +83,8 @@ describe Sambal::Client do
     "#{sub_directory_path}/#{testfile_sub}"
   end
 
+  let(:downloads_path) { Pathname.new('./tmp/downloads') }
+
   describe 'ls' do
     before(:all) do
       FileUtils.cp "#{test_server.share_path}/#{testfile}", "#{test_server.share_path}/#{testfile2}"
@@ -107,31 +112,31 @@ describe Sambal::Client do
   end
 
   it "should get files from an smb server" do
-    @sambal_client.get(testfile, "/tmp/sambal_spec_testfile.txt").should be_successful
-    File.exists?("/tmp/sambal_spec_testfile.txt").should == true
-    File.size("/tmp/sambal_spec_testfile.txt").should == @sambal_client.ls[testfile][:size].to_i
+    @sambal_client.get(testfile, downloads_path.join("sambal_spec_testfile.txt")).should be_successful
+    File.exists?(downloads_path.join("sambal_spec_testfile.txt")).should == true
+    File.size(downloads_path.join("sambal_spec_testfile.txt")).should == @sambal_client.ls[testfile][:size].to_i
   end
 
   it "should get files in a dir with spaces in it's name from an smb server" do
-    @sambal_client.get(test_spaces_in_name_path, "/tmp/sambal_this_file_was_in_dir_with_spaces.txt").should be_successful
-    File.exists?("/tmp/sambal_this_file_was_in_dir_with_spaces.txt").should == true
+    @sambal_client.get(test_spaces_in_name_path, downloads_path.join("sambal_this_file_was_in_dir_with_spaces.txt")).should be_successful
+    File.exists?(downloads_path.join("sambal_this_file_was_in_dir_with_spaces.txt")).should == true
     @sambal_client.cd(test_directory_with_space_in_name)
-    File.size("/tmp/sambal_this_file_was_in_dir_with_spaces.txt").should == @sambal_client.ls[test_file_in_directory_with_space_in_name][:size].to_i
+    File.size(downloads_path.join("sambal_this_file_was_in_dir_with_spaces.txt")).should == @sambal_client.ls[test_file_in_directory_with_space_in_name][:size].to_i
   end
 
   it "should get files in a subdirectory while in a higher level directory from an smb server" do
-    @sambal_client.get(testfile_sub_path, "/tmp/sambal_spec_testfile_sub.txt").should be_successful
-    File.exists?("/tmp/sambal_spec_testfile_sub.txt").should == true
+    @sambal_client.get(testfile_sub_path, downloads_path.join("sambal_spec_testfile_sub.txt")).should be_successful
+    File.exists?(downloads_path.join("sambal_spec_testfile_sub.txt")).should == true
     @sambal_client.cd(sub_directory_path)
-    File.size("/tmp/sambal_spec_testfile_sub.txt").should == @sambal_client.ls[testfile_sub][:size].to_i
+    File.size(downloads_path.join("sambal_spec_testfile_sub.txt")).should == @sambal_client.ls[testfile_sub][:size].to_i
   end
 
   it "should not be successful when getting a file from an smb server fails" do
-    result = @sambal_client.get("non_existant_file.txt", "/tmp/sambal_spec_non_existant_file.txt")
+    result = @sambal_client.get("non_existant_file.txt", downloads_path.join("sambal_spec_non_existant_file.txt"))
     result.should_not be_successful
     result.message.should match /^NT_.*$/
     result.message.split("\n").should have(1).line
-    File.exists?("/tmp/sambal_spec_non_existant_file.txt").should == false
+    File.exists?(downloads_path.join("sambal_spec_non_existant_file.txt")).should == false
   end
 
   it "should upload files to an smb server" do


### PR DESCRIPTION
Hey,

I'm trying to integrate this repo with TravisCI for continuous integration and the first issue I came up with is being unable to use global `/tmp` for hosting a test samba server. So this change moves it to local `./tmp` directory, while also cleaning it up after each run (otherwise some files are left in there in between runs).