### PR TITLE
Preserving smbclient error message on initialisation of sambal

### DIFF
--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -49,6 +49,9 @@ module Sambal
         @o, @i, @pid = PTY.spawn("smbclient \"//#{options[:host]}/#{options[:share]}\" '#{options[:password]}' -W \"#{options[:domain]}\" -U \"#{options[:user]}\" -p #{options[:port]}")
         #@o.set_encoding('UTF-8:UTF-8') ## don't know didn't work, we only have this problem when the files are named using non-english characters
         #@i.set_encoding('UTF-8:UTF-8')
+
+        # Raise if failed to spawn
+        PTY.check(@pid, true)
           
         # Store incase of failure
         smb_response=@o.sysread(1024)

--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -8,8 +8,6 @@ require 'pty'
 require 'expect'
 require 'time'
 require 'tempfile'
-require 'stringio'
-require 'pp'
 
 module Sambal
 

--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -63,15 +63,16 @@ module Sambal
         end
 
         @connected = case res
-        when nil
-          raise RuntimeError.exception("#{smb_response}")
+        when nil # Can probably be removed.
+          $stderr.puts "Failed to connect"
+          false
         when /^put/
           res['putting'].nil? ? false : true
         else
           if res['NT_STATUS']
-            raise RuntimeError.exception("Failed: #{smb_response}")
+            false
           elsif res['timed out'] || res['Server stopped']
-            raise RuntimeError.exception("Failed: #{smb_response}")
+            false
           else
             true
           end

--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -55,10 +55,14 @@ module Sambal
 
         begin
           $expect_verbose=true
-          res = @o.expect(/(.*\n)?smb:.*\\>/, @timeout)[0]
+          res = @o.expect(/(.*\n)?smb:.*\\>/, @timeout)
         rescue Exception => e
           self.close
           raise RuntimeError.exception("PTY.spawn() #{smb_response}: #{e.message}")
+        end
+
+        if not res.nil?
+          res = res[0]
         end
 
         @connected = case res

--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -57,7 +57,8 @@ module Sambal
           $expect_verbose=true
           res = @o.expect(/(.*\n)?smb:.*\\>/, @timeout)[0]
         rescue Exception => e
-          raise RuntimeError.exception("#{smb_response}: #{e.message}")
+          self.close
+          raise RuntimeError.exception("PTY.spawn() #{smb_response}: #{e.message}")
         end
 
         @connected = case res

--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -52,15 +52,14 @@ module Sambal
         res = @o.expect(/(.*\n)?smb:.*\\>/, @timeout)[0] rescue nil
         @connected = case res
         when nil
-          $stderr.puts "Failed to connect"
-          false
+          raise RuntimeError.exception("Failed to connect")
         when /^put/
           res['putting'].nil? ? false : true
         else
           if res['NT_STATUS']
-            false
+            raise RuntimeError.exception("Failed: #{res}")
           elsif res['timed out'] || res['Server stopped']
-            false
+            raise RuntimeError.exception("Failed: #{res}")
           else
             true
           end

--- a/lib/sambal/version.rb
+++ b/lib/sambal/version.rb
@@ -1,5 +1,5 @@
 # coding: UTF-8
 
 module Sambal
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
I read the response from the PTY.spawn and use this as an error message in a new Exception when smbclient does not return the expected output/prompt.