### PR TITLE
Add mkdir method and associated tests

### DIFF
--- a/lib/sambal.rb
+++ b/lib/sambal.rb
@@ -157,6 +157,16 @@ module Sambal
       t.close
     end
 
+    def mkdir(directory)
+      return Response.new('directory name is empty', false) if directory.strip.empty?
+      response = ask_wrapped('mkdir', '"' + directory + '"')
+      if response =~ /NT_STATUS_OBJECT_NAME_(INVALID|COLLISION)/
+        Response.new(response, false)
+      else
+        Response.new(response, true)
+      end
+    end
+
     def rmdir(dir)
       response = cd dir
       return response if response.failure?

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -106,6 +106,45 @@ describe Sambal::Client do
     end
   end
 
+  describe 'mkdir' do
+    before(:all) do
+      @sambal_client.cd('/')
+    end
+
+    it 'should create a new directory' do
+      result = @sambal_client.mkdir('test')
+      result.should be_successful
+
+      @sambal_client.ls.should have_key('test')
+    end
+
+    it 'should create a directory with spaces' do
+      result = @sambal_client.mkdir('test spaces directory')
+      result.should be_successful
+      @sambal_client.ls.should have_key('test spaces directory')
+    end
+
+    it 'should not create an invalid directory' do
+      result = @sambal_client.mkdir('**')
+      result.should_not be_successful
+    end
+
+    it 'should not overwrite an existing directory' do
+      # Ensure our test directory exists
+      @sambal_client.rmdir('test')
+      @sambal_client.mkdir('test')
+      @sambal_client.ls.should have_key('test')
+
+      result = @sambal_client.mkdir('test')
+      result.should_not be_successful
+    end
+
+    it 'should handle empty directory names' do
+      @sambal_client.mkdir('').should_not be_successful
+      @sambal_client.mkdir('   ').should_not be_successful
+    end
+  end
+
   it "should get files from an smb server" do
     @sambal_client.get(testfile, "/tmp/sambal_spec_testfile.txt").should be_successful
     File.exists?("/tmp/sambal_spec_testfile.txt").should == true


### PR DESCRIPTION
mkdir takes in a single argument which is the name of the directory to be created. Directory should have valid characters and spaces are handled accordingly. Added related tests to spec.

```ruby
# Simple directory name
@sambal.mkdir('test').success? # => true
@sambal.cd('test')

# Directory name with spaces
@sambal.mkdir('test folder spaces').sucess? # => true
@sambal_mkdir('test folder spaces')

# Invalid directory name
@sambal.mkdir('*invalid*').success? #  => false
```