### PR TITLE
fix working with long(then more 80 charters) path of folders/files

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -11,11 +11,9 @@ module Sambal
 
     def initialize(options={})
       begin
-        options = {domain: 'WORKGROUP', host: '127.0.0.1', share: '', user: 'guest', password: '--no-pass', port: 445, timeout: 10}.merge(options)
+        options = {domain: 'WORKGROUP', host: '127.0.0.1', share: '', user: 'guest', password: '--no-pass', port: 445, timeout: 10, columns: 80}.merge(options)
         @timeout = options[:timeout].to_i
-        @o, @i, @pid = PTY.spawn("smbclient \"//#{options[:host]}/#{options[:share]}\" '#{options[:password]}' -W \"#{options[:domain]}\" -U \"#{options[:user]}\" -p #{options[:port]}")
-        #@o.set_encoding('UTF-8:UTF-8') ## don't know didn't work, we only have this problem when the files are named using non-english characters
-        #@i.set_encoding('UTF-8:UTF-8')
+        @o, @i, @pid = PTY.spawn("COLUMNS=#{options[:columns]} smbclient \"//#{options[:host]}/#{options[:share]}\" '#{options[:password]}' -W \"#{options[:domain]}\" -U \"#{options[:user]}\" -p #{options[:port]}")
         res = @o.expect(/(.*\n)?smb:.*\\>/, @timeout)[0] rescue nil
         @connected = case res
         when nil


### PR DESCRIPTION
PTY terminal has restriction of columns length (default = 80 charters) by each command row. So after row has more than 80 characters terminal switch to new line (set special symbols) and method 'getc' in IO.expect method can not read these "special symbols' from terminal