### PR TITLE
Close the tempfile after writing

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -139,6 +139,7 @@ module Sambal
       File.open(t.path, 'w') do |f|
         f << content
       end
+      t.close
       response = ask_wrapped 'put', [t.path, destination]
       if response =~ /^putting\sfile.*$/
         Response.new(response, true)
@@ -147,8 +148,6 @@ module Sambal
       end
     rescue InternalError => e
       Response.new(e.message, false)
-    ensure
-      t.close
     end
 
     def mkdir(directory)


### PR DESCRIPTION
Hey, I've just found this Gem so thanks for creating it!
I'm trying to use the `put_content` method to upload PDF files created with Prawn. Without the `t.close` being moved up, the app would cause an error because the tempfile wasn't closed.

This fixes the problem for me but I've not tested it for other use cases