### PR TITLE
Use cleaner exception handling

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -60,8 +60,8 @@ module Sambal
           close if @pid
           exit(1)
         end
-      rescue Exception => e
-        raise RuntimeError.exception("Unknown Process Failed!! (#{$!.to_s}): #{e.message.inspect}\n"+e.backtrace.join("\n"))
+      rescue => e
+        raise RuntimeError, "Unknown Process Failed!! (#{$!.to_s}): #{e.message.inspect}\n"+e.backtrace.join("\n")
       end
     end
 
@@ -242,7 +242,7 @@ module Sambal
       response = @output.expect(/^smb:.*\\>/,@timeout)[0] rescue nil
       if response.nil?
         $stderr.puts "Failed to do #{cmd}"
-        raise Exception.new, "Failed to do #{cmd}"
+        raise "Failed to do #{cmd}"
       else
         response
       end


### PR DESCRIPTION
We ran into an issue recently where this library is using the top level `Exception` class instead of the lower-level `StandardError`. If you rescue exception, you also rescue issues like out of memory, SIGTERM, and other things that should rarely be rescued. This also means that the standard

```ruby
begin
  # Do stuff
rescue => e
  # handle the issue
end
```

doesn't capture exceptions emitted by this application.

This PR switches to using `StandardError`/`RuntimeError`, which keeps things cleaner for consuming applications.

Thanks!