### PR TITLE
Ability to rename remote files

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -122,6 +122,17 @@ module Sambal
       end
     end
 
+    def rename(old_filename, new_filename)
+      response = ask_wrapped 'rename', [old_filename, new_filename]
+      if response =~ /^renaming\sfile.*$/ # "renaming" reponse only exist if has error
+        Response.new(response, false)
+      else
+        Response.new(response, true)
+      end
+    rescue InternalError => e
+      Response.new(e.message, false)
+    end
+
     def put(file, destination)
       response = ask_wrapped 'put', [file, destination]
       if response =~ /^putting\sfile.*$/

--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -124,7 +124,7 @@ module Sambal
 
     def rename(old_filename, new_filename)
       response = ask_wrapped 'rename', [old_filename, new_filename]
-      if response =~ /^renaming\sfile.*$/ # "renaming" reponse only exist if has error
+      if response =~ /renaming\sfile/ # "renaming" reponse only exist if has error
         Response.new(response, false)
       else
         Response.new(response, true)

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -145,6 +145,10 @@ describe Sambal::Client do
       expect(@sambal_client.rename(TESTFILE, 'renamed_file.txt')).to be_successful
       expect(File.exists?(File.join(test_server.share_path, 'renamed_file.txt'))).to eq true
     end
+
+    it 'is unsuccessful when the file does not exist' do
+      expect(@sambal_client.rename('unknown_file.txt', 'renamed_file.txt')).not_to be_successful
+    end
   end
 
   it "should get files from an smb server" do

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -140,6 +140,13 @@ describe Sambal::Client do
     end
   end
 
+  describe 'rename' do
+    it 'is successful when renaming an existing file' do
+      expect(@sambal_client.rename(TESTFILE, 'renamed_file.txt')).to be_successful
+      expect(File.exists?(File.join(test_server.share_path, 'renamed_file.txt'))).to eq true
+    end
+  end
+
   it "should get files from an smb server" do
     expect(@sambal_client.get(TESTFILE, "/tmp/sambal_spec_testfile.txt")).to be_successful
     expect(File.exists?("/tmp/sambal_spec_testfile.txt")).to eq true


### PR DESCRIPTION
Replacement for #33 with specs added and a small bug fixed in the error code path. Thanks to @manoktsina for the original work!

Adds the ability to rename files on the remote share.