### PR TITLE
Support of missed `smbclient` options

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -31,13 +31,17 @@ module Sambal
         options = parsed_options(user_options)
         @timeout = options[:timeout].to_i
 
-        option_flags = "-W \"#{options[:domain]}\" -U \"#{options[:user]}\""
-        option_flags = "#{option_flags} -I #{options[:ip_address]}" if options[:ip_address]
-        option_flags = "#{option_flags} -p #{options[:port]} -s /dev/null"
-        password = options[:password] ? "'#{options[:password]}'" : "--no-pass"
+        password =
+          if options[:authfile]
+            "--authentication-file #{options[:authfile]}"
+          elsif options[:password]
+            options[:password]
+          else
+            '--no-pass'
+          end
         command = "COLUMNS=#{options[:columns]} smbclient \"//#{options[:host]}/#{options[:share]}\" #{password}"
 
-        @output, @input, @pid = PTY.spawn(command + ' ' + option_flags)
+        @output, @input, @pid = PTY.spawn("#{command} #{option_flags(options)}")
 
         res = @output.expect(/(.*\n)?smb:.*\\>/, @timeout)[0] rescue nil
         @connected = case res
@@ -284,6 +288,25 @@ module Sambal
         files
       end
       Hash[listing.sort]
+    end
+
+    private
+
+    def option_flags(options)
+      flags = []
+      flags << "--workgroup \"#{options[:domain]}\"" if options[:domain] && !options[:authfile]
+      flags << "--user \"#{options[:user]}\"" if options[:user] && !options[:authfile]
+      flags << "--ip-address #{options[:ip_address]}" if options[:ip_address]
+      flags << "--send-buffer #{options[:buffer_size]}" if options[:buffer_size]
+      flags << "--debuglevel #{options[:debug_level]}" if options[:debug_level]
+      flags << '--encrypt' if options[:encrypt]
+      flags << "--max-protocol #{options[:max_protocol]}" if options[:max_protocol]
+      flags << '--use-ccache' if options[:use_ccache]
+      flags << "--socket-options #{options[:socket_options]}" if options[:socket_options]
+      flags << "--port #{options[:port]}" if options[:port]
+      flags << "--name-resolve #{options[:name_resolve]}" if options[:name_resolve]
+      flags << (options[:configfile] ? "--configfile #{options[:configfile]}" : '--configfile /dev/null')
+      flags.join(' ')
     end
   end
 end


### PR DESCRIPTION
New options:
--authentication-file
--send-buffer
--debuglevel
--encrypt
--max-protocol
--use-ccache
--socket-options
--name-resolve
--configfile
Also replaced short option names to readable equivalent

I wanted to write tests but it's not trivial (need refactor).
In commit there one assumption:
if user set `:authfile` option, then `:user`, `:password` and `:domain` should not be used (and will be ignored).
Not sure that it right but better solution also need big refactor