### PR TITLE
Fix printf bug with filenames containing '%'

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -252,7 +252,7 @@ module Sambal
     end
 
     def ask(cmd)
-      @input.printf("#{cmd}\n")
+      @input.print("#{cmd}\n")
       response = @output.expect(/^smb:.*\\>/,@timeout)[0] rescue nil
       if response.nil?
         $stderr.puts "Failed to do #{cmd}"


### PR DESCRIPTION
Steps to reproduce the bug:
```ruby
smb_client = Sambal::Client.new # supply connection args here
smb_client.ls('test%20file.wav')
# This raises an `ArgumentError` tracing back to the `printf`
# in `lib/sambal/client.rb` method `ask`.
```

When the first argument to `IO#printf` (in this case, a command string containing a filename) contains a `%` character, `printf` expects additional arguments to supply data to the `%`-encoded fields of the first argument. Sambal is not passing a `%`-formatted string or data field args, so this branch replaces `printf` with `print`.
