### PR TITLE
Prevent smb command injection

### DIFF
--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -266,9 +266,13 @@ module Sambal
       ask wrap_filenames(cmd,filenames)
     end
 
+    def sanitize_filename(filename)
+      filename.to_s.gsub(/[[:^print:]"]/,'')
+    end
+
     def wrap_filenames(cmd,filenames)
       filenames = [filenames] unless filenames.kind_of?(Array)
-      filenames.map!{ |filename| "\"#{filename}\"" }
+      filenames.map!{ |filename| "\"#{sanitize_filename(filename)}\"" }
       [cmd,filenames].flatten.join(' ')
     end
 

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -257,4 +257,9 @@ describe Sambal::Client do
     expect(@sambal_client.wrap_filenames('cmd',[Pathname.new('file1'), Pathname.new('file2')])).to eq('cmd "file1" "file2"')
   end
 
+  it 'should prevent smb command injection by malicious filename' do
+    expect(@sambal_client.exists?('evil.txt')).to be_falsy
+    @sambal_client.ls("\b\b\b\bput \"#{file_to_upload.path}\" \"evil.txt")
+    expect(@sambal_client.exists?('evil.txt')).to be_falsy
+  end
 end

--- a/spec/sambal/client_spec.rb
+++ b/spec/sambal/client_spec.rb
@@ -262,4 +262,13 @@ describe Sambal::Client do
     @sambal_client.ls("\b\b\b\bput \"#{file_to_upload.path}\" \"evil.txt")
     expect(@sambal_client.exists?('evil.txt')).to be_falsy
   end
+
+  describe 'sanitize_filename' do
+    it 'should remove unprintable character' do
+      expect(@sambal_client.sanitize_filename("fi\b\ble\n name\r\n")).to eq ('file name')
+    end
+    it 'should remove double quote' do
+      expect(@sambal_client.sanitize_filename('double"quote')).to eq ('doublequote')
+    end
+  end
 end


### PR DESCRIPTION
I made filename as sanitized that removes non printable chars and double quotes.
This PR prevents smb command injection by malicious filename.