### PR TITLE
Dir.glob instead of git ls-files

### DIFF
--- a/sambal.gemspec
+++ b/sambal.gemspec
@@ -8,9 +8,8 @@ Gem::Specification.new do |gem|
   gem.summary       = %q{Ruby Samba Client}
   gem.homepage      = "https://github.com/johnae/sambal"
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.files         = Dir.glob("{bin,lib}/**/*") + %w(LICENSE README.md)
+  gem.test_files    = Dir.glob("{spec}/**/*")
   gem.name          = "sambal"
   gem.require_paths = ["lib"]
   gem.version       = Sambal::VERSION


### PR DESCRIPTION
Do not rely on 'git' to list files.  It should be used Dir.glob instead.

There is a problem in the following cases
* when using package downloaded from GitHub as an archive(like tar.gz, zip)
* when not installed .git environment

ref: 
https://github.com/bundler/bundler/issues/6281
https://www.codinginthecrease.com/news_article/show/350843-using-git-in-your-gemspec

