### PR TITLE
Parse both NT_STATUS_OBJECT_NAME_NOT_FOUND and NT_STATUS_OBJECT_PATH_NOT_FOUND response from smbclient as non-existing directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ spec/smb.conf
 test/tmp
 test/version_tmp
 tmp
+ruby

--- a/lib/sambal/client.rb
+++ b/lib/sambal/client.rb
@@ -105,7 +105,7 @@ module Sambal
 
     def cd(dir)
       response = ask("cd \"#{dir}\"")
-      if response.split("\r\n").join('') =~ /NT_STATUS_OBJECT_NAME_NOT_FOUND/
+      if response.split("\r\n").join('') =~ /NT_STATUS_OBJECT_(NAME|PATH)_NOT_FOUND/
         Response.new(response, false)
       else
         Response.new(response, true)


### PR DESCRIPTION
When trying to cd to a non existing directory, the version of smbclient I use responds with NT_STATUS_OBJECT_PATH_NOT_FOUND , the client#cd method tries to find the string NT_STATUS_OBJECT_NAME_NOT_FOUND , with this pull requests both strings are interpreted  as a non existing directory.